### PR TITLE
prefer isGV_with_GP_on over SvSCREAM_on

### DIFF
--- a/Alias.xs
+++ b/Alias.xs
@@ -98,6 +98,9 @@
 #ifndef GvCV_set
 #define GvCV_set(gv, val) (GvCV(gv) = (val))
 #endif
+#ifndef isGV_with_GP_on /* < 5.9.5 */
+#define isGV_with_GP_on(gv) SvSCREAM_on(gv)
+#endif
 
 #if (PERL_COMBI_VERSION >= 5009003)
 #define DA_FEATURE_MULTICALL 1
@@ -516,7 +519,7 @@ static void da_unlocalize_gvar(pTHX_ void *gp_v) {
 	} else {
 		SV *gv = newSV(0);
 		sv_upgrade(gv, SVt_PVGV);
-		SvSCREAM_on(gv);
+		isGV_with_GP_on(gv);
 		GvGP_set(gv, gp);
 		sv_free(gv);
 	}


### PR DESCRIPTION
The former is the preferred API since perl 5.9.5. Only fall back to SvSCREAM_on if the more sensible name isn't defined.

Fixes [RT 173582](https://rt.cpan.org/Ticket/Display.html?id=173582).